### PR TITLE
Level-order traversal

### DIFF
--- a/examples/traverse_level_order.rs
+++ b/examples/traverse_level_order.rs
@@ -1,0 +1,16 @@
+use avl::AvlTreeMap;
+
+fn main() {
+    let mut map = AvlTreeMap::new();
+    map.insert(1, "1");
+    map.insert(2, "2");
+    map.insert(3, "3");
+    map.insert(4, "4");
+    map.insert(5, "5");
+    map.insert(6, "6");
+
+    println!("Level-order traversal:");
+    map.traverse_level_order(|k, v| {
+        println!("Key: {}, Value: {}", k, v);
+    });
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -504,6 +504,32 @@ impl<K, V> AvlTreeMap<K, V> {
             assert_eq!(num_nodes, self.num_nodes);
         }
     }
+
+    pub fn traverse_level_order<F>(&self, mut f: F)
+    where
+        F: FnMut(&K, &V),
+    {
+        if let Some(root_ptr) = self.root {
+            let mut queue = Vec::new();
+            queue.push(root_ptr);
+            let mut i = 0;
+            while i < queue.len() {
+                let node_ptr = queue[i];
+                i += 1;
+                unsafe {
+                    let node_ref = node_ptr.as_ref();
+                    f(&node_ref.key, &node_ref.value);
+                    if let Some(left_ptr) = node_ref.left {
+                        queue.push(left_ptr);
+                    }
+                    if let Some(right_ptr) = node_ref.right {
+                        queue.push(right_ptr);
+                    }
+                }
+            }
+        }
+    }
+    
 }
 // endregion Public implementation of AvlTreeMap
 


### PR DESCRIPTION
I needed to perform a level-wise traversal of an AVL tree and found your library to be excellent. I am submitting a patch that adds this functionality to the AVL tree. It would be interesting to consider including this function in Set in future updates.